### PR TITLE
fix: don't validate wearable thumbnail file when it is already stored

### DIFF
--- a/test/unit/validations/wearables.spec.ts
+++ b/test/unit/validations/wearables.spec.ts
@@ -101,6 +101,20 @@ describe('Wearables', () => {
 
       expect(result.ok).toBeTruthy()
     })
+
+    it(`When thumbnail file was already uploaded, it won't be validated again`, async () => {
+      const content = [{ file: fileName, hash }]
+      const entity = buildEntity({ type: EntityType.WEARABLE, metadata: VALID_WEARABLE_METADATA, content, timestamp })
+      const deployment = buildDeployment({ entity })
+
+      const externalCalls = buildExternalCalls({
+        isContentStoredAlready: async () => new Map([[hash, true]]),
+      })
+
+      const result = await wearableThumbnail.validate({ deployment, externalCalls })
+
+      expect(result.ok).toBeTruthy()
+    })
   })
 
   describe('Size:', () => {


### PR DESCRIPTION
## Description

Validations are now live in `peer-testing-2` and there are some failed deployments related to the wearable thumbnail checks. 

This PR includes a change to avoid validation when the thumbnail is already stored, because in that case, validation will alwasys fails trying to get it from the uploaded files.