### PR TITLE
Remove support for default scenes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,32 @@
 {
+  "files.exclude": {
+    "**/dist/": true,
+    "**/node_modules/": true,
+    "**/coverage/": true
+  },
+  "editor.formatOnSave": true,
+  "cSpell.words": [
+    "comms",
+    "Ethereum",
+    "IPFS",
+    "Metaverse",
+    "openapi"
+  ],
+  "editor.rulers": [
+    120
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
+  },
+  "eslint.validate": [
+    "typescript"
+  ],
   "files.associations": {
     "*.json": "jsonc"
-  }
+  },
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+  "typescript.preferences.importModuleSpecifier": "relative",
 }

--- a/src/validations/access-checker/scenes.ts
+++ b/src/validations/access-checker/scenes.ts
@@ -311,31 +311,25 @@ export const scenes: Validation = {
     const lowerCasePointers = pointers.map((pointer) => pointer.toLowerCase())
 
     for (const pointer of lowerCasePointers) {
-      if (pointer.startsWith('default')) {
-        if (!externalCalls.isAddressOwnedByDecentraland(ethAddress)) {
-          errors.push(`Only Decentraland can add or modify default scenes`)
+      const pointerParts: string[] = pointer.split(',')
+      if (pointerParts.length === 2) {
+        const x: number = parseInt(pointerParts[0], 10)
+        const y: number = parseInt(pointerParts[1], 10)
+        try {
+          // Check that the address has access (we check both the present and the 5 min into the past to avoid synchronization issues in the blockchain)
+          const hasAccess =
+            (await checkParcelAccess(x, y, timestamp, ethAddress, externalCalls)) ||
+            (await checkParcelAccess(x, y, timestamp - SCENE_LOOKBACK_TIME, ethAddress, externalCalls))
+          if (!hasAccess) {
+            errors.push(`The provided Eth Address does not have access to the following parcel: (${x},${y})`)
+          }
+        } catch (e) {
+          errors.push(`The provided Eth Address does not have access to the following parcel: (${x},${y}). ${e}`)
         }
       } else {
-        const pointerParts: string[] = pointer.split(',')
-        if (pointerParts.length === 2) {
-          const x: number = parseInt(pointerParts[0], 10)
-          const y: number = parseInt(pointerParts[1], 10)
-          try {
-            // Check that the address has access (we check both the present and the 5 min into the past to avoid synchronization issues in the blockchain)
-            const hasAccess =
-              (await checkParcelAccess(x, y, timestamp, ethAddress, externalCalls)) ||
-              (await checkParcelAccess(x, y, timestamp - SCENE_LOOKBACK_TIME, ethAddress, externalCalls))
-            if (!hasAccess) {
-              errors.push(`The provided Eth Address does not have access to the following parcel: (${x},${y})`)
-            }
-          } catch (e) {
-            errors.push(`The provided Eth Address does not have access to the following parcel: (${x},${y}). ${e}`)
-          }
-        } else {
-          errors.push(
-            `Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: ${pointer}`
-          )
-        }
+        errors.push(
+          `Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: ${pointer}`
+        )
       }
     }
 

--- a/test/unit/access/scenes.spec.ts
+++ b/test/unit/access/scenes.spec.ts
@@ -13,10 +13,10 @@ describe('Access: scenes', () => {
 
     const response = await scenes.validate({ deployment, externalCalls })
     expect(response.ok).toBeFalsy()
-    expect(response.errors).toContain('Only Decentraland can add or modify default scenes')
+    expect(response.errors).toContain('Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: default10')
   })
 
-  it('When a decentraland address tries to deploy an default scene, then it is allowed', async () => {
+  it('When a decentraland address tries to deploy an default scene, then it is not allowed', async () => {
     const pointers = ['Default10']
     const deployment = buildSceneDeployment(pointers)
     const externalCalls = buildExternalCalls({
@@ -25,7 +25,7 @@ describe('Access: scenes', () => {
     })
 
     const response = await scenes.validate({ deployment, externalCalls })
-    expect(response.ok).toBeTruthy()
+    expect(response.ok).toBeFalsy()
   })
 
   it('When non-urns are used as pointers, then validation fails', async () => {


### PR DESCRIPTION
As part of https://github.com/decentraland/catalyst/pull/969, the default scenes are being removed from the Content Servers: not only no new default scenes can be created, but also it will be invalid to sync old default scenes.