### PR TITLE
chore: add publish-on-tag workflow

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,6 +1,7 @@
 on:
-  tags:
-    - '*'
+  push:
+    tags:
+      - '*'
 
 name: Publish NPM package
 jobs:

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,40 @@
+on:
+  tags:
+    - '*'
+
+name: Publish NPM package
+jobs:
+
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: ${{ success() }}
+    env:
+      NODE_AUTH_TOKEN: stub
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+      - name: install
+        run:  yarn install --frozen-lockfile
+      - name: check code lint
+        run:  yarn lint:check
+      - name: build
+        run:  yarn build
+      - name: api-extractor
+        run:  yarn api-extractor-ci
+      - name: Publish
+        uses: menduz/oddish-action@master
+        with:
+          registry-url: "https://registry.npmjs.org"
+          access: public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Publish npm package when a commit is tagged