### PR TITLE
feat: add validation for ADR45

### DIFF
--- a/etc/content-validator.api.md
+++ b/etc/content-validator.api.md
@@ -86,7 +86,7 @@ export type QueryGraph = <T = any>(query: string, variables?: Variables, remaini
 export const statefulValidations: readonly [Validation, Validation, Validation, Validation, Validation, Validation, Validation];
 
 // @public
-export const statelessValidations: readonly [Validation, Validation, Validation];
+export const statelessValidations: readonly [Validation, Validation, Validation, Validation];
 
 // @public
 export type SubGraphs = {
@@ -130,7 +130,7 @@ export type ValidationResponse = {
 };
 
 // @public
-export const validations: readonly [Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation];
+export const validations: readonly [Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation, Validation];
 
 // @public
 export interface Validator {

--- a/src/validations/ADR45.ts
+++ b/src/validations/ADR45.ts
@@ -1,0 +1,22 @@
+import { Entity } from '@dcl/schemas'
+import { ContentValidatorComponents, OK, Validation, validationFailed } from '../types'
+import { ADR_45_TIMESTAMP } from './timestamps'
+
+const entityIsNotVersion3 = (entity: Entity) => entity.version !== 'v3'
+
+const entityWasDeployedAfterADR45 = (entity: Entity) => entity.timestamp > ADR_45_TIMESTAMP
+
+/**
+ * Validate that entity meets ADR-45 validations
+ * @public
+ */
+export const adr45: Validation = {
+  validate: async (components: ContentValidatorComponents, deployment) => {
+    const { entity } = deployment
+
+    if (entityIsNotVersion3(entity) && entityWasDeployedAfterADR45(entity))
+      return validationFailed('Only entities v3 are allowed after ADR-45')
+
+    return OK
+  }
+}

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -1,4 +1,5 @@
 import { DeploymentToValidate, ExternalCalls } from '../types'
+import { adr45 } from './ADR45'
 import { access } from './access-checker/access'
 import { content } from './content'
 import { entityStructure } from './entity-structure'
@@ -41,7 +42,7 @@ export const statefulValidations = [signature, access, size, wearable, emote, pr
  * Stateless validations that are run on a deployment.
  * @public
  */
-export const statelessValidations = [entityStructure, ipfsHashing, metadata] as const
+export const statelessValidations = [entityStructure, ipfsHashing, metadata, adr45] as const
 
 /**
  * All validations that are run on a deployment.


### PR DESCRIPTION
This PR adds the entity validations for the [ADR-45](https://adr.decentraland.org/adr/ADR-45) which was previously placed in catalyst, specifically [here](https://github.com/decentraland/catalyst/blob/main/content/src/service/ServiceImpl.ts#L231-L234).