### PR TITLE
fix: allow base wearables

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@dcl/block-indexer": "^1.1.1-4056737184.commit-2112891",
     "@dcl/content-hash-tree": "^1.1.4",
     "@dcl/hashing": "1.1.3",
-    "@dcl/schemas": "^6.4.1",
+    "@dcl/schemas": "^6.13.3-20230321190550.commit-a76266d",
     "@dcl/urn-resolver": "2.0.3",
     "@well-known-components/interfaces": "1.2.0",
     "@well-known-components/thegraph-component": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@dcl/block-indexer": "^1.1.1-4056737184.commit-2112891",
     "@dcl/content-hash-tree": "^1.1.4",
     "@dcl/hashing": "1.1.3",
-    "@dcl/schemas": "^6.13.3-20230321190550.commit-a76266d",
+    "@dcl/schemas": "^6.13.4",
     "@dcl/urn-resolver": "2.0.3",
     "@well-known-components/interfaces": "1.2.0",
     "@well-known-components/thegraph-component": "^1.2.0",

--- a/test/setup/wearable.ts
+++ b/test/setup/wearable.ts
@@ -29,6 +29,32 @@ const representation: WearableRepresentation = {
   overrideReplaces: []
 }
 
+export const BASE_WEARABLE_METADATA: Pick<Wearable, 'id' | 'i18n' | 'data' | 'thumbnail'> = {
+  id: 'urn:decentraland:off-chain:base-avatars:BaseMale',
+  i18n: [
+    {
+      code: Locale.EN,
+      text: 'name'
+    }
+  ],
+  data: {
+    replaces: [],
+    hides: [],
+    tags: ['tag1'],
+    representations: [
+      {
+        bodyShapes: [BodyShape.FEMALE],
+        mainFile: 'file1',
+        contents: ['file1', 'file2'],
+        overrideHides: [],
+        overrideReplaces: []
+      }
+    ],
+    category: WearableCategory.UPPER_BODY
+  },
+  thumbnail: 'thumbnail.png'
+}
+
 export const VALID_WEARABLE_METADATA: Wearable = {
   id: 'some id',
   name: 'name',

--- a/test/unit/validations/metadata-schema.spec.ts
+++ b/test/unit/validations/metadata-schema.spec.ts
@@ -92,4 +92,19 @@ describe('Metadata Schema', () => {
 
     expect(result.ok).toBeTruthy()
   })
+
+  it('when deploying an invalid base wearable the errors are reported correctly', async () => {
+    const expectedErrors = ["must have required property 'i18n'", "must have required property 'id'"]
+
+    const entity = buildEntity({
+      type: EntityType.WEARABLE,
+      metadata: { ...BASE_WEARABLE_METADATA, i18n: undefined, id: undefined }
+    })
+    const deployment = buildDeployment({ entity })
+    const result = await metadataValidateFn(deployment)
+
+    expect(result.ok).toBeFalsy()
+    expect(result.errors).toContain(`The metadata for this entity type (${EntityType.WEARABLE}) is not valid.`)
+    expectedErrors.forEach(($) => expect(result.errors).toContain($))
+  })
 })

--- a/test/unit/validations/metadata-schema.spec.ts
+++ b/test/unit/validations/metadata-schema.spec.ts
@@ -5,7 +5,7 @@ import { buildDeployment } from '../../setup/deployments'
 import { VALID_STANDARD_EMOTE_METADATA, VALID_THIRD_PARTY_EMOTE_METADATA_WITH_MERKLE_ROOT } from '../../setup/emotes'
 import { buildEntity } from '../../setup/entity'
 import { VALID_PROFILE_METADATA } from '../../setup/profiles'
-import { VALID_THIRD_PARTY_WEARABLE, VALID_WEARABLE_METADATA } from '../../setup/wearable'
+import { BASE_WEARABLE_METADATA, VALID_THIRD_PARTY_WEARABLE, VALID_WEARABLE_METADATA } from '../../setup/wearable'
 
 describe('Metadata Schema', () => {
   const POST_ADR_45_TIMESTAMP = ADR_45_TIMESTAMP + 1
@@ -75,6 +75,17 @@ describe('Metadata Schema', () => {
       type: EntityType.PROFILE,
       metadata: invalidMetadata,
       timestamp: PRE_ADR_45_TIMESTAMP
+    })
+    const deployment = buildDeployment({ entity })
+    const result = await metadataValidateFn(deployment)
+
+    expect(result.ok).toBeTruthy()
+  })
+
+  it('when deploying a base wearable the validation pass', async () => {
+    const entity = buildEntity({
+      type: EntityType.WEARABLE,
+      metadata: BASE_WEARABLE_METADATA
     })
     const deployment = buildDeployment({ entity })
     const result = await metadataValidateFn(deployment)

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,10 +438,10 @@
     ipfs-unixfs-importer "^7.0.3"
     multiformats "^9.6.3"
 
-"@dcl/schemas@^6.4.1":
-  version "6.13.2"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-6.13.2.tgz#23e946883259e0d84d7f3299eea3f0d4ec1edc1a"
-  integrity sha512-PbgfjyMGbZxSHeOW/kD1m8siAXDPlhhjPdozv1KX9S9BOMxJjEkacW59j3u8BYhIu4vD1kaAG+qnOnaFxXxVFA==
+"@dcl/schemas@^6.13.3-20230321190550.commit-a76266d":
+  version "6.13.3-20230321190550.commit-a76266d"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-6.13.3-20230321190550.commit-a76266d.tgz#f6467f6ccd5479559e94599b86c7c71ceff7b07e"
+  integrity sha512-F2/s+IKcTnUram0dPFUDkyFfpOTq88IoEUuXaTwITfuCmhyLuSh5cJv5wj6wc4cKUs1t7PjuOdBcHQkCEodBYg==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,10 +438,10 @@
     ipfs-unixfs-importer "^7.0.3"
     multiformats "^9.6.3"
 
-"@dcl/schemas@^6.13.3-20230321190550.commit-a76266d":
-  version "6.13.3-20230321190550.commit-a76266d"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-6.13.3-20230321190550.commit-a76266d.tgz#f6467f6ccd5479559e94599b86c7c71ceff7b07e"
-  integrity sha512-F2/s+IKcTnUram0dPFUDkyFfpOTq88IoEUuXaTwITfuCmhyLuSh5cJv5wj6wc4cKUs1t7PjuOdBcHQkCEodBYg==
+"@dcl/schemas@^6.13.4":
+  version "6.13.4"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-6.13.4.tgz#215bf0330dfda40afa10b3d9d7e2ca6dfcaaa8da"
+  integrity sha512-e8ninpyRPP6WkW6BhkD+irWQpbXpfi0tu1AXMHIq0yyBOTlPRPV8Igyc9yOTqSIHjR3keqaa7n9RJpn9xMyppw==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
@@ -1810,12 +1810,12 @@ aes-js@3.0.0:
 
 ajv-errors@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
   integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
 
 ajv-keywords@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
   dependencies:
     fast-deep-equal "^3.1.3"
@@ -1831,9 +1831,9 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@~6.12.6:
     uri-js "^4.2.2"
 
 ajv@^8.11.0:
-  version "8.11.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3135,7 +3135,7 @@ express@^4.18.1:
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
@@ -4433,7 +4433,7 @@ json-schema-traverse@^0.4.1:
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
@@ -5155,9 +5155,9 @@ pump@^3.0.0:
     once "^1.3.1"
 
 punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 qs@6.11.0:
   version "6.11.0"
@@ -5261,7 +5261,7 @@ require-directory@^2.1.1:
 
 require-from-string@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-cwd@^3.0.0:
@@ -5965,7 +5965,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
 
 uri-js@^4.2.2:
   version "4.4.1"
-  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"


### PR DESCRIPTION
This PR bumps the version of @dcl/schemas so it admits base wearables deployment.

Also it adds a UT validating that these types of wearables are now valid.