### PR TITLE
chore: avoid publishing notification on PR for dependabots branches

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
   notify_deployment:
     needs: [check_and_build]
-    if: ${{ github.event.pull_request.number }}
+    if: ${{ github.event.pull_request.number && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     name: Deployment Notification
     steps:


### PR DESCRIPTION
This PR avoids running the pipeline that publishes the notification on the PR for dependabot branches.