### PR TITLE
feat: execute subgraph scenes validations in parallel with eager failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Install dependencies and run tests:
 
 ```
 > yarn
-> make build
-> make test
+> yarn build
+> yarn test
 ```
 
 ### Debugging tests
@@ -28,5 +28,5 @@ To make Catalysts accept deployments of new entity types, they must have defined
 
 1. Create entity schema on [@dcl/schemas](https://github.com/decentraland/common-schemas).
 2. Add entity type and schema on [catalyst-commons](https://github.com/decentraland/catalyst-commons/).
-3. Add entity type and access checker in [access.ts](./src/validations/access-checker/access.ts).  
+3. Add entity type and access checker in [access.ts](./src/validations/access-checker/access.ts).
    a. Verify entity pointers can be resolved. If required add a new resolver in [@dcl/urn-resolver](https://github.com/decentraland/urn-resolver).

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@well-known-components/interfaces": "^1.3.0",
     "@well-known-components/thegraph-component": "^1.4.3",
     "ms": "^2.1.3",
+    "p-queue": "^6.6.2",
     "sharp": "^0.32.0"
   },
   "files": [

--- a/test/unit/subgraph-access-checker/scenes.spec.ts
+++ b/test/unit/subgraph-access-checker/scenes.spec.ts
@@ -1,10 +1,11 @@
 import { createSceneValidateFn } from '../../../src/validations/access/subgraph/scenes'
 import { buildSceneDeployment } from '../../setup/deployments'
 import { buildExternalCalls } from '../../setup/mock'
-import { buildSubgraphAccessCheckerComponents } from './mock'
+import { buildSubGraphs, buildSubgraphAccessCheckerComponents } from './mock'
 
 describe('Access: scenes', () => {
   it('When a non-decentraland address tries to deploy a default scene, then an error is returned', async () => {
+    // Arrange
     const pointers = ['Default10']
     const deployment = buildSceneDeployment(pointers)
     const externalCalls = buildExternalCalls({
@@ -12,8 +13,11 @@ describe('Access: scenes', () => {
       ownerAddress: () => '0xAddress'
     })
 
+    // Act
     const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
     const response = await validateFn(deployment)
+
+    // Assert
     expect(response.ok).toBeFalsy()
     expect(response.errors).toContain(
       'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: default10'
@@ -21,6 +25,7 @@ describe('Access: scenes', () => {
   })
 
   it('When a decentraland address tries to deploy an default scene, then it is not allowed', async () => {
+    // Arrange
     const pointers = ['Default10']
     const deployment = buildSceneDeployment(pointers)
     const externalCalls = buildExternalCalls({
@@ -28,12 +33,16 @@ describe('Access: scenes', () => {
       ownerAddress: () => '0xAddress'
     })
 
+    // Act
     const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
     const response = await validateFn(deployment)
+
+    // Assert
     expect(response.ok).toBeFalsy()
   })
 
   it('When non-urns are used as pointers, then validation fails', async () => {
+    // Arrange
     const pointers = ['invalid-pointer']
     const deployment = buildSceneDeployment(pointers)
     const externalCalls = buildExternalCalls({
@@ -41,11 +50,237 @@ describe('Access: scenes', () => {
       ownerAddress: () => '0xAddress'
     })
 
+    // Act
     const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
     const response = await validateFn(deployment)
+
+    // Assert
     expect(response.ok).toBeFalsy()
     expect(response.errors).toContain(
       'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: invalid-pointer'
     )
   })
+
+  it('When valid deployment is sent, then the validation passes', async () => {
+    // Arrange
+    const pointers = ['0,1']
+    const deployment = buildSceneDeployment(pointers)
+    const externalCalls = buildExternalCalls({
+      isAddressOwnedByDecentraland: () => true,
+      ownerAddress: () => '0xAddress'
+    })
+
+    const subgraphsMocks = buildSubGraphs({
+      L1: {
+        blocks: { query: jest.fn() },
+        ensOwner: { query: jest.fn() },
+        collections: { query: jest.fn() },
+        landManager: {
+          query: jest.fn().mockResolvedValue(
+            generateGetParcelResponseFromPointers(
+              [
+                [0, 1],
+                [2, 3],
+                [4, 5],
+                [5, 6]
+              ],
+              '0xAddress'
+            )
+          )
+        }
+      }
+    })
+
+    // Act
+    const validateFn = createSceneValidateFn(
+      buildSubgraphAccessCheckerComponents({
+        externalCalls,
+        subGraphs: subgraphsMocks
+      })
+    )
+
+    const response = await validateFn(deployment)
+
+    // Assert
+    expect(subgraphsMocks.L1.landManager.query).toHaveBeenCalledTimes(1)
+    expect(response.ok).toBeTruthy()
+    expect(response.errors).toBeUndefined()
+  })
+
+  it('When a pointer validation = false, then the validation returns false and the pending checks are avoided w/concurrency=1', async () => {
+    // Arrange
+    process.env.SCENE_VALIDATIONS_CONCURRENCY = '1'
+    const pointers = ['0,1', '9,9', '2,3', '4,5', '5,6']
+    const deployment = buildSceneDeployment(pointers)
+    const externalCalls = buildExternalCalls({
+      isAddressOwnedByDecentraland: () => true,
+      ownerAddress: () => '0xAddress'
+    })
+
+    const queryMock = jest.fn()
+    const subgraphsMocks = buildSubGraphs({
+      L1: {
+        blocks: { query: jest.fn() },
+        ensOwner: { query: jest.fn() },
+        collections: { query: jest.fn() },
+        landManager: { query: queryMock }
+      }
+    })
+
+    const notOwnedParcels = generateGetParcelResponseFromPointers(
+      [
+        [0, 1],
+        [2, 3],
+        [4, 5],
+        [5, 6]
+      ],
+      '0xDifferent'
+    )
+
+    queryMock
+      .mockResolvedValueOnce(
+        generateGetParcelResponseFromPointers(
+          [
+            [0, 1],
+            [2, 3],
+            [4, 5],
+            [5, 6]
+          ],
+          '0xAddress'
+        )
+      )
+      .mockImplementation((_query, variables) => {
+        if (variables.x === 9 && variables.y === 9) return new Promise((resolve) => resolve(notOwnedParcels))
+
+        if (variables.owner === '0xdifferent')
+          return new Promise((resolve) =>
+            resolve({
+              authorizations: [
+                { type: 'Operator', isApproved: false },
+                { type: 'ApprovalForAll', isApproved: false },
+                { type: 'UpdateManager', isApproved: false }
+              ]
+            })
+          )
+      })
+
+    // Act
+    const validateFn = createSceneValidateFn(
+      buildSubgraphAccessCheckerComponents({
+        externalCalls,
+        subGraphs: subgraphsMocks
+      })
+    )
+
+    const response = await validateFn(deployment)
+
+    // Assert
+    expect(response.ok).toBeFalsy()
+    expect(response.errors).toContain('The provided Eth Address does not have access to the following parcel: (9,9)')
+
+    // Verify that after one validation fails, the other ones are not executed
+    expect(subgraphsMocks.L1.landManager.query).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: 2,
+        y: 3
+      })
+    )
+
+    expect(subgraphsMocks.L1.landManager.query).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: 4,
+        y: 5
+      })
+    )
+
+    expect(subgraphsMocks.L1.landManager.query).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: 5,
+        y: 6
+      })
+    )
+  })
+
+  it.only('When a validation fails, then the validation returns false and the pending checks are avoided w/concurrency=2', async () => {
+    // Arrange
+    process.env.SCENE_VALIDATIONS_CONCURRENCY = '2'
+    const pointers = ['0,1', '2,3', '9,9', '4,5', '5,6', '4,4', '4,4', '9,9', '9,9']
+    const deployment = buildSceneDeployment(pointers)
+    const externalCalls = buildExternalCalls({
+      isAddressOwnedByDecentraland: () => true,
+      ownerAddress: () => '0xAddress'
+    })
+
+    const queryMock = jest.fn()
+    const subgraphsMocks = buildSubGraphs({
+      L1: {
+        blocks: { query: jest.fn() },
+        ensOwner: { query: jest.fn() },
+        collections: { query: jest.fn() },
+        landManager: { query: queryMock }
+      }
+    })
+
+    const notOwnedParcels = generateGetParcelResponseFromPointers(
+      [
+        [0, 1],
+        [2, 3],
+        [4, 5],
+        [5, 6]
+      ],
+      '0xDifferent'
+    )
+
+    queryMock.mockImplementation((_query, variables) => {
+      if (variables.x === 9 && variables.y === 9) return new Promise((resolve) => resolve(notOwnedParcels))
+
+      if (variables.owner === '0xdifferent')
+        return new Promise((resolve) =>
+          resolve({
+            authorizations: [
+              { type: 'Operator', isApproved: false },
+              { type: 'ApprovalForAll', isApproved: false },
+              { type: 'UpdateManager', isApproved: false }
+            ]
+          })
+        )
+
+      return generateGetParcelResponseFromPointers(
+        [
+          [0, 1],
+          [2, 3],
+          [4, 5],
+          [5, 6]
+        ],
+        '0xAddress'
+      )
+    })
+
+    // Act
+    const validateFn = createSceneValidateFn(
+      buildSubgraphAccessCheckerComponents({
+        externalCalls,
+        subGraphs: subgraphsMocks
+      })
+    )
+
+    const response = await validateFn(deployment)
+
+    expect(response.ok).toBeFalsy()
+    // The rest of the errors are not added because the validation chain is aborted as soon as the first fails
+    expect(response.errors?.length).toBe(1)
+  })
+})
+
+const generateGetParcelResponseFromPointers = (pointers: number[][], address: string) => ({
+  parcels: pointers.map((pointer) => ({
+    owners: [{ address: address }],
+    operators: [],
+    updateOperators: [],
+    x: pointer[0],
+    y: pointer[1]
+  }))
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,6 +3058,11 @@ ethers@^5.6.8:
     "@ethersproject/web" "5.6.1"
     "@ethersproject/wordlists" "5.6.1"
 
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
@@ -4833,6 +4838,11 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
@@ -4867,6 +4877,21 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-queue@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
The changes in this pull request relate to the way subgraph scene validations are conducted. Going forward, validations will be executed in parallel with a default concurrency of 10. If any validation fails, the remaining validations will be aborted.

Performance measures comparing old approach with new approach will be added to this PR. I'll delay the merge until then but the code can already be reviewed since I confirmed the approach is working through unit tests.