### PR TITLE
feat: extended URNs for dcl wearables / emotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@dcl/content-hash-tree": "^1.1.4",
     "@dcl/hashing": "^3.0.1",
     "@dcl/schemas": "^9.1.1",
-    "@dcl/urn-resolver": "^2.0.3",
+    "@dcl/urn-resolver": "3.1.0",
     "@well-known-components/interfaces": "^1.3.0",
     "@well-known-components/thegraph-component": "^1.5.0",
     "ms": "^2.1.3",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,42 @@
+import { parseUrn } from '@dcl/urn-resolver'
+import { L1_NETWORKS, L2_NETWORKS } from './types'
+
+type URNsByNetwork = {
+  ethereum: { urn: string; type: string }[]
+  matic: { urn: string; type: string }[]
+}
+
+const ITEM_TYPES_TO_SPLIT = [
+  'blockchain-collection-v1-asset',
+  'blockchain-collection-v1-item',
+  'blockchain-collection-v2-asset',
+  'blockchain-collection-v2-item'
+]
+
+export async function splitItemsURNsByNetwork(urnsToSplit: string[]): Promise<URNsByNetwork> {
+  const ethereum: { urn: string; type: string }[] = []
+  const matic: { urn: string; type: string }[] = []
+  for (const urn of urnsToSplit) {
+    // check if it is a L1 or L2 asset
+    // 'ethereum' is included since L1 Mainnet assets includes it instead of 'mainnet'
+    if (
+      ![...L1_NETWORKS, 'ethereum'].some((network) => urn.includes(network)) &&
+      !L2_NETWORKS.some((network) => urn.includes(network))
+    ) {
+      continue
+    }
+
+    const parsed = await parseUrn(urn)
+    if (parsed && 'network' in parsed && ITEM_TYPES_TO_SPLIT.includes(parsed.type)) {
+      if (L1_NETWORKS.includes(parsed.network)) {
+        ethereum.push({ urn, type: parsed.type })
+      } else if (L2_NETWORKS.includes(parsed.network)) {
+        matic.push({ urn, type: parsed.type })
+      }
+    }
+  }
+  return {
+    ethereum,
+    matic
+  }
+}

--- a/src/validations/access/on-chain/client.ts
+++ b/src/validations/access/on-chain/client.ts
@@ -166,7 +166,7 @@ export const createOnChainClient = (
         }
         return runQuery(query, {
           block: blockNumber,
-          ethAddress,
+          ethAddress: ethAddress.toLowerCase(),
           urnList: urnsToQuery
         })
       }

--- a/src/validations/access/on-chain/client.ts
+++ b/src/validations/access/on-chain/client.ts
@@ -154,15 +154,13 @@ export const createOnChainClient = (
           description: 'check for items ownership',
           subgraph: collectionsSubgraph,
           query: QUERY_ITEMS_FOR_ADDRESS_AT_BLOCK,
-          mapper: (response: { items: { urn: string; tokenId: string }[] }): Set<{ urn: string; tokenId: string }> => {
-            console.log({ response: JSON.stringify(response, null, 2) })
-            return new Set(
+          mapper: (response: { items: { urn: string; tokenId: string }[] }): Set<{ urn: string; tokenId: string }> =>
+            new Set(
               response.items.map(({ urn, tokenId }) => ({
                 urn,
                 tokenId
               }))
             )
-          }
         }
         return runQuery(query, {
           block: blockNumber,
@@ -174,9 +172,6 @@ export const createOnChainClient = (
       try {
         const ownedItems = await runOwnedItemsOnBlockQuery(blockNumber)
         const ownedItemsArray = Array.from(ownedItems)
-
-        console.log('Client', { urnsToQuery })
-        console.log('Client', { ownedItemsArray: JSON.stringify(ownedItemsArray, null, 2) })
         let notOwned = extendedUrnsSplit
           .filter(({ urn, tokenId }) => {
             return !ownedItemsArray.some((item) => item.urn === urn && item.tokenId === tokenId)
@@ -185,7 +180,6 @@ export const createOnChainClient = (
 
         notOwned = notOwned.concat(notExtendedUrns.filter((urn) => !ownedItemsArray.some((item) => item.urn === urn)))
 
-        console.log('Client', { notOwned })
         return notOwned.length > 0 ? permissionError(notOwned) : permissionOk()
       } catch (error) {
         logger.error(`Error retrieving items owned by address ${ethAddress} at block ${blocks.blockNumberAtDeployment}`)
@@ -205,7 +199,6 @@ export const createOnChainClient = (
     query: Query<QueryResult, ReturnType>,
     variables: Record<string, any>
   ): Promise<ReturnType> => {
-    console.log('Running query', { query: query.query, variables })
     const response = await query.subgraph.query<QueryResult>(query.query, variables)
     return query.mapper(response)
   }
@@ -249,7 +242,7 @@ query getNftItemsForBlock($block: Int!, $ethAddress: String!, $urnList: [String!
     where: {owner: $ethAddress, searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"] urn_in: $urnList}
     first: 1000
   ) {
-    urn,
+    urn
     tokenId
   }
 }`

--- a/src/validations/access/subgraph/the-graph-client.ts
+++ b/src/validations/access/subgraph/the-graph-client.ts
@@ -119,28 +119,15 @@ export const createTheGraphClient = (
       return permissionOk()
     }
 
-    // Urns that need to be split into urn and tokenId
-    const extendedUrns = urnsToCheck
-      .filter(
-        (urn) =>
-          urn.type.includes('blockchain-collection-v1-item') || urn.type.includes('blockchain-collection-v2-item')
-      )
-      .map((urn) => urn.urn)
-    const extendedUrnsSplit = extendedUrns.map((extendedUrn) => {
-      const { assetUrn, tokenId } = getTokenIdAndAssetUrn(extendedUrn)
-      return { urn: assetUrn, tokenId }
+    const urnsToQuery = urnsToCheck.map((urn) => {
+      if (urn.type === 'blockchain-collection-v1-item' || urn.type === 'blockchain-collection-v2-item') {
+        // Urns that need to be split into urn and tokenId
+        const { assetUrn } = getTokenIdAndAssetUrn(urn.urn)
+        return assetUrn
+      } else {
+        return urn.urn
+      }
     })
-
-    // Urns that don't need to be split
-    const notExtendedUrns = urnsToCheck
-      .filter(
-        (urn) =>
-          !urn.type.includes('blockchain-collection-v1-item') && !urn.type.includes('blockchain-collection-v2-item')
-      )
-      .map((urn) => urn.urn)
-
-    // we should always query with shortened URNs
-    const urnsToQuery = notExtendedUrns.concat(Array.from(extendedUrnsSplit).map((item) => item.urn))
 
     const blocks = await findBlocksForTimestamp(blocksSubgraph, timestamp)
 
@@ -172,14 +159,18 @@ export const createTheGraphClient = (
       try {
         const ownedItems = await runOwnedItemsOnBlockQuery(blockNumber)
         const ownedItemsArray = Array.from(ownedItems)
+        const notOwned: string[] = []
 
-        let notOwned = extendedUrnsSplit
-          .filter(({ urn, tokenId }) => {
-            return !ownedItemsArray.some((item) => item.urn === urn && item.tokenId === tokenId)
-          })
-          .map(({ urn, tokenId }) => `${urn}:${tokenId}`)
-
-        notOwned = notOwned.concat(notExtendedUrns.filter((urn) => !ownedItemsArray.some((item) => item.urn === urn)))
+        for (const urn of urnsToCheck) {
+          if (urn.type === 'blockchain-collection-v1-item' || urn.type === 'blockchain-collection-v2-item') {
+            const { assetUrn, tokenId } = getTokenIdAndAssetUrn(urn.urn)
+            if (!ownedItemsArray.some((item) => item.urn === assetUrn && item.tokenId === tokenId)) {
+              notOwned.push(urn.urn)
+            }
+          } else if (!ownedItemsArray.some((item) => item.urn === urn.urn)) {
+            notOwned.push(urn.urn)
+          }
+        }
 
         return notOwned.length > 0 ? permissionError(notOwned) : permissionOk()
       } catch (error) {

--- a/src/validations/access/subgraph/the-graph-client.ts
+++ b/src/validations/access/subgraph/the-graph-client.ts
@@ -173,6 +173,9 @@ export const createTheGraphClient = (
         const ownedItems = await runOwnedItemsOnBlockQuery(blockNumber)
         const ownedItemsArray = Array.from(ownedItems)
 
+        console.log('The Graph Client', { urnsToQuery })
+        console.log('The Graph Client', { ownedItemsArray: JSON.stringify(ownedItemsArray, null, 2) })
+
         let notOwned = extendedUrnsSplit
           .filter(({ urn, tokenId }) => {
             return !ownedItemsArray.some((item) => item.urn === urn && item.tokenId === tokenId)
@@ -180,6 +183,7 @@ export const createTheGraphClient = (
           .map(({ urn, tokenId }) => `${urn}:${tokenId}`)
 
         notOwned = notOwned.concat(notExtendedUrns.filter((urn) => !ownedItemsArray.some((item) => item.urn === urn)))
+        console.log('The Graph Client', { notOwned })
 
         return notOwned.length > 0 ? permissionError(notOwned) : permissionOk()
       } catch (error) {

--- a/src/validations/access/subgraph/the-graph-client.ts
+++ b/src/validations/access/subgraph/the-graph-client.ts
@@ -173,9 +173,6 @@ export const createTheGraphClient = (
         const ownedItems = await runOwnedItemsOnBlockQuery(blockNumber)
         const ownedItemsArray = Array.from(ownedItems)
 
-        console.log('The Graph Client', { urnsToQuery })
-        console.log('The Graph Client', { ownedItemsArray: JSON.stringify(ownedItemsArray, null, 2) })
-
         let notOwned = extendedUrnsSplit
           .filter(({ urn, tokenId }) => {
             return !ownedItemsArray.some((item) => item.urn === urn && item.tokenId === tokenId)
@@ -183,7 +180,6 @@ export const createTheGraphClient = (
           .map(({ urn, tokenId }) => `${urn}:${tokenId}`)
 
         notOwned = notOwned.concat(notExtendedUrns.filter((urn) => !ownedItemsArray.some((item) => item.urn === urn)))
-        console.log('The Graph Client', { notOwned })
 
         return notOwned.length > 0 ? permissionError(notOwned) : permissionOk()
       } catch (error) {

--- a/test/unit/on-chain-access-checker/client.spec.ts
+++ b/test/unit/on-chain-access-checker/client.spec.ts
@@ -85,7 +85,8 @@ describe('OnChainClient', () => {
         jest.fn().mockResolvedValue({
           items: [
             {
-              urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet'
+              urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+              tokenId: '123'
             }
           ]
         })
@@ -94,7 +95,8 @@ describe('OnChainClient', () => {
         jest.fn().mockResolvedValue({
           items: [
             {
-              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2'
+              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+              tokenId: '123'
             }
           ]
         })
@@ -116,7 +118,7 @@ describe('OnChainClient', () => {
         components.client.ownsItemsAtTimestamp(
           '0x1',
           [
-            'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+            'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123',
             'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2'
           ],
           10
@@ -134,7 +136,8 @@ describe('OnChainClient', () => {
             return Promise.resolve({
               items: [
                 {
-                  urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet'
+                  urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+                  tokenId: '123'
                 }
               ]
             })
@@ -146,7 +149,8 @@ describe('OnChainClient', () => {
         jest.fn().mockResolvedValue({
           items: [
             {
-              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2'
+              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+              tokenId: '123'
             }
           ]
         })
@@ -202,6 +206,161 @@ describe('OnChainClient', () => {
           currentTimestamp
         )
       ).resolves.toEqual({ result: false, failing: [] })
+    })
+
+    it.each([
+      [
+        'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+        'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2'
+      ],
+      [
+        'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123',
+        'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:321'
+      ]
+    ])(
+      'should validate ownership of v1 and v2 wearables (passing and not passing tokenId)',
+      async (l1UrnToValidate, l2UrnToValidate) => {
+        const components = buildOnChainAccessCheckerComponents()
+        components.L1.collections = createMockSubgraphComponent(
+          jest.fn().mockResolvedValue({
+            items: [
+              {
+                urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+                tokenId: '123'
+              }
+            ]
+          })
+        )
+        components.L2.collections = createMockSubgraphComponent(
+          jest.fn().mockResolvedValue({
+            items: [
+              {
+                urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+                tokenId: '321'
+              }
+            ]
+          })
+        )
+        components.L1.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+          if (t === bounds.upper) {
+            return undefined
+          }
+          return { timestamp: bounds.lower, block: 123400 }
+        })
+        components.L2.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+          if (t === bounds.upper) {
+            return undefined
+          }
+          return { timestamp: bounds.lower, block: 123400 }
+        })
+
+        await expect(
+          components.client.ownsItemsAtTimestamp('0x1', [l1UrnToValidate, l2UrnToValidate], 10)
+        ).resolves.toEqual({ result: true })
+      }
+    )
+
+    it('should fail validate ownership of v1 and v2 items with invalid token id', async () => {
+      const components = buildOnChainAccessCheckerComponents()
+      components.L1.collections = createMockSubgraphComponent(
+        jest.fn().mockResolvedValue({
+          items: [
+            {
+              urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+              tokenId: '123'
+            }
+          ]
+        })
+      )
+      components.L2.collections = createMockSubgraphComponent(
+        jest.fn().mockResolvedValue({
+          items: [
+            {
+              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+              tokenId: '123'
+            }
+          ]
+        })
+      )
+      components.L1.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+        if (t === bounds.upper) {
+          return undefined
+        }
+        return { timestamp: bounds.lower, block: 123400 }
+      })
+      components.L2.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+        if (t === bounds.upper) {
+          return undefined
+        }
+        return { timestamp: bounds.lower, block: 123400 }
+      })
+
+      await expect(
+        components.client.ownsItemsAtTimestamp(
+          '0x1',
+          [
+            'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:124',
+            'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:124'
+          ],
+          10
+        )
+      ).resolves.toEqual({
+        result: false,
+        failing: [
+          'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:124',
+          'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:124'
+        ]
+      })
+    })
+
+    it('should fail validate ownership of a single wearable which has invalid token id', async () => {
+      const components = buildOnChainAccessCheckerComponents()
+      components.L1.collections = createMockSubgraphComponent(
+        jest.fn().mockResolvedValue({
+          items: [
+            {
+              urn: 'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet',
+              tokenId: '123'
+            }
+          ]
+        })
+      )
+      components.L2.collections = createMockSubgraphComponent(
+        jest.fn().mockResolvedValue({
+          items: [
+            {
+              urn: 'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2',
+              tokenId: '123'
+            }
+          ]
+        })
+      )
+      components.L1.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+        if (t === bounds.upper) {
+          return undefined
+        }
+        return { timestamp: bounds.lower, block: 123400 }
+      })
+      components.L2.blockSearch.findBlockForTimestamp = jest.fn().mockImplementation((t) => {
+        if (t === bounds.upper) {
+          return undefined
+        }
+        return { timestamp: bounds.lower, block: 123400 }
+      })
+
+      await expect(
+        components.client.ownsItemsAtTimestamp(
+          '0x1',
+          [
+            'urn:decentraland:ethereum:collections-v1:rtfkt_x_atari:p_rtfkt_x_atari_feet:123',
+            'urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:124'
+          ],
+          10
+        )
+      ).resolves.toEqual({
+        result: false,
+        failing: ['urn:decentraland:matic:collections-v2:0x04e7f74e73e951c61edd80910e46c3fece5ebe80:2:124']
+      })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,10 +350,10 @@
     ajv-errors "^3.0.0"
     ajv-keywords "^5.1.0"
 
-"@dcl/urn-resolver@^2.0.3":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@dcl/urn-resolver/-/urn-resolver-2.2.0.tgz#ea0759fd6f6584a83a07e7da7766966ae86245da"
-  integrity sha512-Ut399wl+YyGS9k9zzgENePK31YIEAK+triaqgUMPA44TO4bKOR6MxjjZe1RDYTkL5E8+6Q8tlaVXnz+xuVEK+g==
+"@dcl/urn-resolver@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/urn-resolver/-/urn-resolver-3.1.0.tgz#bc9ba521cde55e9e1b1bcbfaf428097e61fb72c4"
+  integrity sha512-g68ERxXPOYtBk1IMYtmWlCg8geX8AHCat/HLDOBNBcJIvNOEwGcnASYzENfdGa8mr8r7GlNmdI1O2ymn8V8aHw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"


### PR DESCRIPTION
This PR modifies the `QUERY_ITEMS_FOR_ADDRESS_AT_BLOCK` query in order for it to retrieve the tokenId from The Graph and then be able to ensure the unique identification of each minted emote / wearable item by validating their tokenId property.