### PR TITLE
break: Update @dcl/schemas to change how profile's links are validated

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@dcl/block-indexer": "^1.1.1",
     "@dcl/content-hash-tree": "^1.1.4",
     "@dcl/hashing": "^3.0.1",
-    "@dcl/schemas": "^10.3.0",
+    "@dcl/schemas": "^11.0.0",
     "@dcl/urn-resolver": "^3.3.1",
     "@well-known-components/interfaces": "^1.3.0",
     "@well-known-components/thegraph-component": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,10 +341,10 @@
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-3.0.4.tgz#4df2a4cb3a8114765aed34cb57b91c93bf33bfb3"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
-"@dcl/schemas@^10.3.0":
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-10.4.0.tgz#8cb19d6710635938c1746c4e4b8eed9a1bbce43b"
-  integrity sha512-gd69ProYNRxU4YqY7hruLlWdtfHfAuBdn10LIg0kPayvIraBX78emulVFy47r7qDRiqscRn6+1KLyIfMkXEBdA==
+"@dcl/schemas@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-11.0.0.tgz#5893fd56b2461d96465964d50d45a8f99c347468"
+  integrity sha512-gBwW3Sv6pIebl3xddJ7mUrIA92e5CsZXV4RdBis56UU/3w7FunwGPBcHoQLkJVvuy8SVHYHNt7PVDEkNSfVHWw==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
This PR updates the @dcl/schemas package to its latest breaking change version.