### PR TITLE
fix: Profiles without contents should allow 1 file to be uploaded

### DIFF
--- a/src/validations/profile.ts
+++ b/src/validations/profile.ts
@@ -284,7 +284,7 @@ export async function entityShouldNotHaveContentFilesValidateFn(
     if (entity.content.length > 0) {
       errors.push(`Entity has content files when it should not: ${entity.content.map((a) => a.file).join(', ')}`)
     }
-    if (deployment.files.size > 0) {
+    if (deployment.files.size > 1) {
       errors.push(`Entity has uploaded files when it should not: ${Array.from(deployment.files.keys()).join(', ')}`)
     }
     return fromErrors(...errors)

--- a/test/unit/validations/profiles.spec.ts
+++ b/test/unit/validations/profiles.spec.ts
@@ -1071,6 +1071,17 @@ describe('when validating that the entity should not have content files', () => 
       })
     })
 
+    describe('and the profile only has the entity file', () => {
+      beforeEach(() => {
+        files.set('entityHash', new Uint8Array())
+      })
+
+      it('should return ok', async () => {
+        const result: ValidationResponse = await entityShouldNotHaveContentFilesValidateFn(deployment)
+        expect(result.ok).toBe(true)
+      })
+    })
+
     describe('and the entity has content', () => {
       beforeEach(() => {
         content.push({ file: 'body.png', hash: 'hash1' })
@@ -1083,15 +1094,16 @@ describe('when validating that the entity should not have content files', () => 
       })
     })
 
-    describe('and the entity has uploaded files', () => {
+    describe('and the entity has uploaded files beyond the entity file', () => {
       beforeEach(() => {
+        files.set('entityHash', new Uint8Array())
         files.set('hash1', new Uint8Array())
       })
 
-      it('should return an error with the uploaded file hash', async () => {
+      it('should return an error with the uploaded file hashes', async () => {
         const result: ValidationResponse = await entityShouldNotHaveContentFilesValidateFn(deployment)
         expect(result.ok).toBe(false)
-        expect(result.errors).toContain(`Entity has uploaded files when it should not: hash1`)
+        expect(result.errors).toContain(`Entity has uploaded files when it should not: entityHash, hash1`)
       })
     })
   })


### PR DESCRIPTION
This PR fixes an issue where profiles without contents weren't allowed to have one file uploaded along de profile deployment. All deployments have one file, which is the entity.