### PR TITLE
feat: validate new nearbyVoiceChat scene option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dcl/block-indexer": "^1.1.2",
     "@dcl/content-hash-tree": "^1.1.4",
     "@dcl/hashing": "^3.0.4",
-    "@dcl/schemas": "^23.0.0",
+    "@dcl/schemas": "^26.1.0",
     "@dcl/urn-resolver": "^3.6.0",
     "@well-known-components/interfaces": "^1.4.3",
     "@well-known-components/thegraph-component": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,10 +309,10 @@
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-3.0.4.tgz#4df2a4cb3a8114765aed34cb57b91c93bf33bfb3"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
-"@dcl/schemas@^23.0.0":
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-23.0.0.tgz#e15486e64b2f19e30a1be7edb3f551ceaf0999b8"
-  integrity sha512-DChEhcQZA3Q5uKsa5Z+5aG+bpIiqTCf8dOdx6dta0XmtCrdqMJgGuzu2ZW//7EmzXH6zlgsI+pUv3JpTFlleOA==
+"@dcl/schemas@^26.1.0":
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-26.1.0.tgz#07a08df2e40450f4540fd4c5e7fb5de46348d5b2"
+  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
This PR updates the `@dcl/schemas` dependency to check for the new `nearbyVoiceChat` property in the `scene.json`.
Referenced in #419.