### PR TITLE
fix: add null guards, NaN checks, and try-catch to prevent runtime crashes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,12 @@ export async function splitItemsURNsByTypeAndNetwork(urnsToSplit: string[]): Pro
   const maticThirdParty: { urn: string; type: string }[] = []
 
   for (const urn of urnsToSplit) {
-    const asset = await parseUrn(urn)
+    let asset
+    try {
+      asset = await parseUrn(urn)
+    } catch {
+      continue
+    }
     if (!asset || !('network' in asset) || !ITEM_TYPES_TO_SPLIT.includes(asset.type)) {
       continue
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,18 @@ const ITEM_TYPES_TO_SPLIT = [
   'blockchain-collection-third-party-item'
 ]
 
+/**
+ * Wraps parseUrn in a try-catch so callers don't need to handle thrown exceptions.
+ * Returns null if the URN cannot be parsed for any reason.
+ */
+export async function safeParseUrn(urn: string) {
+  try {
+    return await parseUrn(urn)
+  } catch {
+    return null
+  }
+}
+
 export async function splitItemsURNsByTypeAndNetwork(urnsToSplit: string[]): Promise<URNsByNetwork> {
   const ethereum: { urn: string; type: string }[] = []
   const matic: { urn: string; type: string }[] = []
@@ -24,12 +36,7 @@ export async function splitItemsURNsByTypeAndNetwork(urnsToSplit: string[]): Pro
   const maticThirdParty: { urn: string; type: string }[] = []
 
   for (const urn of urnsToSplit) {
-    let asset
-    try {
-      asset = await parseUrn(urn)
-    } catch {
-      continue
-    }
+    const asset = await safeParseUrn(urn)
     if (!asset || !('network' in asset) || !ITEM_TYPES_TO_SPLIT.includes(asset.type)) {
       continue
     }

--- a/src/validations/access/on-chain/scenes.ts
+++ b/src/validations/access/on-chain/scenes.ts
@@ -29,6 +29,13 @@ export function createSceneValidateFn({
         const x: number = parseInt(pointerParts[0], 10)
         const y: number = parseInt(pointerParts[1], 10)
 
+        if (isNaN(x) || isNaN(y)) {
+          errors.push(
+            `Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: ${pointer}`
+          )
+          continue
+        }
+
         batch.push([x, y])
       } else {
         errors.push(

--- a/src/validations/access/subgraph/scenes.ts
+++ b/src/validations/access/subgraph/scenes.ts
@@ -52,9 +52,10 @@ export function createSceneValidateFn({
   const logger = logs.getLogger('scenes access validator')
 
   const SCENE_LOOKBACK_TIME = ms('5m')
-  const SCENE_VALIDATIONS_CONCURRENCY = process.env.SCENE_VALIDATIONS_CONCURRENCY
+  const parsedConcurrency = process.env.SCENE_VALIDATIONS_CONCURRENCY
     ? parseInt(process.env.SCENE_VALIDATIONS_CONCURRENCY)
     : 10
+  const SCENE_VALIDATIONS_CONCURRENCY = isNaN(parsedConcurrency) || parsedConcurrency <= 0 ? 10 : parsedConcurrency
 
   return async function validateFn(deployment: DeploymentToValidate): Promise<ValidationResponse> {
     const getAuthorizations = async (
@@ -358,6 +359,7 @@ export function createSceneValidateFn({
             `Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: ${pointer}`
           )
           controller.abort()
+          queue.clear()
           break
         }
 

--- a/src/validations/access/subgraph/scenes.ts
+++ b/src/validations/access/subgraph/scenes.ts
@@ -273,12 +273,20 @@ export function createSceneValidateFn({
     ): Promise<boolean> => {
       const estate = await getEstate(estateId.toString(), timestamp)
       if (estate) {
-        return (
-          (await hasAccessThroughFirstLevelAuthorities(estate, ethAddress)) ||
-          (await hasAccessThroughAuthorizations(estate.owners[0].address, ethAddress, timestamp, tokenAddresses.estate))
+        if (await hasAccessThroughFirstLevelAuthorities(estate, ethAddress)) {
+          return true
+        }
+        if (estate.owners.length === 0) {
+          return false
+        }
+        return await hasAccessThroughAuthorizations(
+          estate.owners[0].address,
+          ethAddress,
+          timestamp,
+          tokenAddresses.estate
         )
       }
-      throw new Error(`Couldn\'t find the state ${estateId}`)
+      throw new Error(`Couldn\'t find the estate ${estateId}`)
     }
 
     const isParcelUpdateAuthorized = async (
@@ -299,16 +307,17 @@ export function createSceneValidateFn({
         const belongsToEstate: boolean =
           parcel.estates !== undefined && parcel.estates.length > 0 && parcel.estates[0].estateId !== undefined
 
-        return (
-          (await hasAccessThroughFirstLevelAuthorities(parcel, ethAddress)) ||
-          (await hasAccessThroughAuthorizations(
-            parcel.owners[0].address,
-            ethAddress,
-            timestamp,
-            tokenAddresses.land
-          )) ||
-          (belongsToEstate && (await isEstateUpdateAuthorized(parcel.estates[0].estateId, timestamp, ethAddress)))
-        )
+        if (await hasAccessThroughFirstLevelAuthorities(parcel, ethAddress)) {
+          return true
+        }
+        if (parcel.owners.length > 0) {
+          if (
+            await hasAccessThroughAuthorizations(parcel.owners[0].address, ethAddress, timestamp, tokenAddresses.land)
+          ) {
+            return true
+          }
+        }
+        return belongsToEstate && (await isEstateUpdateAuthorized(parcel.estates[0].estateId, timestamp, ethAddress))
       }
       throw new Error(`Parcel(${x},${y},${timestamp}) not found`)
     }
@@ -343,6 +352,14 @@ export function createSceneValidateFn({
       if (pointerParts.length === 2) {
         const x: number = parseInt(pointerParts[0], 10)
         const y: number = parseInt(pointerParts[1], 10)
+
+        if (isNaN(x) || isNaN(y)) {
+          errors.push(
+            `Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: ${pointer}`
+          )
+          controller.abort()
+          break
+        }
 
         // Check that the address has access (we check both the present and the 5 min into the past to avoid synchronization issues in the blockchain)
         queue

--- a/src/validations/access/subgraph/scenes.ts
+++ b/src/validations/access/subgraph/scenes.ts
@@ -52,9 +52,7 @@ export function createSceneValidateFn({
   const logger = logs.getLogger('scenes access validator')
 
   const SCENE_LOOKBACK_TIME = ms('5m')
-  const parsedConcurrency = process.env.SCENE_VALIDATIONS_CONCURRENCY
-    ? parseInt(process.env.SCENE_VALIDATIONS_CONCURRENCY)
-    : 10
+  const parsedConcurrency = parseInt(process.env.SCENE_VALIDATIONS_CONCURRENCY ?? '')
   const SCENE_VALIDATIONS_CONCURRENCY = isNaN(parsedConcurrency) || parsedConcurrency <= 0 ? 10 : parsedConcurrency
 
   return async function validateFn(deployment: DeploymentToValidate): Promise<ValidationResponse> {
@@ -274,17 +272,15 @@ export function createSceneValidateFn({
     ): Promise<boolean> => {
       const estate = await getEstate(estateId.toString(), timestamp)
       if (estate) {
-        if (await hasAccessThroughFirstLevelAuthorities(estate, ethAddress)) {
-          return true
-        }
-        if (estate.owners.length === 0) {
-          return false
-        }
-        return await hasAccessThroughAuthorizations(
-          estate.owners[0].address,
-          ethAddress,
-          timestamp,
-          tokenAddresses.estate
+        return (
+          (await hasAccessThroughFirstLevelAuthorities(estate, ethAddress)) ||
+          (estate.owners.length > 0 &&
+            (await hasAccessThroughAuthorizations(
+              estate.owners[0].address,
+              ethAddress,
+              timestamp,
+              tokenAddresses.estate
+            )))
         )
       }
       throw new Error(`Couldn\'t find the estate ${estateId}`)
@@ -308,17 +304,17 @@ export function createSceneValidateFn({
         const belongsToEstate: boolean =
           parcel.estates !== undefined && parcel.estates.length > 0 && parcel.estates[0].estateId !== undefined
 
-        if (await hasAccessThroughFirstLevelAuthorities(parcel, ethAddress)) {
-          return true
-        }
-        if (parcel.owners.length > 0) {
-          if (
-            await hasAccessThroughAuthorizations(parcel.owners[0].address, ethAddress, timestamp, tokenAddresses.land)
-          ) {
-            return true
-          }
-        }
-        return belongsToEstate && (await isEstateUpdateAuthorized(parcel.estates[0].estateId, timestamp, ethAddress))
+        return (
+          (await hasAccessThroughFirstLevelAuthorities(parcel, ethAddress)) ||
+          (parcel.owners.length > 0 &&
+            (await hasAccessThroughAuthorizations(
+              parcel.owners[0].address,
+              ethAddress,
+              timestamp,
+              tokenAddresses.land
+            ))) ||
+          (belongsToEstate && (await isEstateUpdateAuthorized(parcel.estates[0].estateId, timestamp, ethAddress)))
+        )
       }
       throw new Error(`Parcel(${x},${y},${timestamp}) not found`)
     }

--- a/src/validations/entity-structure.ts
+++ b/src/validations/entity-structure.ts
@@ -6,10 +6,10 @@ import { DeploymentToValidate, OK, validationFailed, ValidationResponse } from '
  */
 export async function entityStructureValidationFn(deployment: DeploymentToValidate): Promise<ValidationResponse> {
   const { entity } = deployment
-  if (new Set(entity.pointers).size !== entity.pointers.length) {
-    return validationFailed('There are repeated pointers in your request.')
-  } else if (!entity.pointers || entity.pointers.length <= 0) {
+  if (!entity.pointers || entity.pointers.length <= 0) {
     return validationFailed('The entity needs to be pointed by one or more pointers.')
+  } else if (new Set(entity.pointers).size !== entity.pointers.length) {
+    return validationFailed('There are repeated pointers in your request.')
   }
   return OK
 }

--- a/src/validations/outfits.ts
+++ b/src/validations/outfits.ts
@@ -1,5 +1,4 @@
 import { EntityType, EthAddress, Outfits } from '@dcl/schemas'
-import { parseUrn } from '@dcl/urn-resolver'
 import {
   ContentValidatorComponents,
   DeploymentToValidate,
@@ -8,6 +7,7 @@ import {
   ValidationResponse,
   validationFailed
 } from '../types'
+import { safeParseUrn } from '../utils'
 import { validateAfterADR244, validateAll, validateIfTypeMatches } from './validations'
 
 export function createOutfitsPointerValidateFn(
@@ -85,12 +85,7 @@ export const outfitsWearableUrnsIncludeTokenIdFn = validateAfterADR244(async fun
   const invalidUrns: string[] = []
   const nonItemUrns: string[] = []
   for (const wearableUrn of [...new Set(allWearables)]) {
-    let parsed
-    try {
-      parsed = await parseUrn(wearableUrn)
-    } catch {
-      // treat thrown exceptions the same as unresolvable URNs
-    }
+    const parsed = await safeParseUrn(wearableUrn)
     if (!parsed) {
       invalidUrns.push(wearableUrn)
     } else if (parsed.type === 'blockchain-collection-v1-asset' || parsed.type === 'blockchain-collection-v2-asset') {

--- a/src/validations/outfits.ts
+++ b/src/validations/outfits.ts
@@ -85,7 +85,12 @@ export const outfitsWearableUrnsIncludeTokenIdFn = validateAfterADR244(async fun
   const invalidUrns: string[] = []
   const nonItemUrns: string[] = []
   for (const wearableUrn of [...new Set(allWearables)]) {
-    const parsed = await parseUrn(wearableUrn)
+    let parsed
+    try {
+      parsed = await parseUrn(wearableUrn)
+    } catch {
+      // treat thrown exceptions the same as unresolvable URNs
+    }
     if (!parsed) {
       invalidUrns.push(wearableUrn)
     } else if (parsed.type === 'blockchain-collection-v1-asset' || parsed.type === 'blockchain-collection-v2-asset') {

--- a/src/validations/profile.ts
+++ b/src/validations/profile.ts
@@ -75,7 +75,12 @@ export async function wearableUrnsValidateFn(deployment: DeploymentToValidate): 
       for (const pointer of avatar.avatar.wearables) {
         if (isOldEmote(pointer)) continue
 
-        const parsed = await parseUrn(pointer)
+        let parsed
+        try {
+          parsed = await parseUrn(pointer)
+        } catch {
+          // treat thrown exceptions the same as unresolvable URNs
+        }
         if (!parsed) {
           return validationFailed(
             `Each profile wearable pointer should be a urn, for example (urn:decentraland:{protocol}:collections-v2:{contract(0x[a-fA-F0-9]+)}:{name}). Invalid pointer: (${pointer})`
@@ -102,7 +107,12 @@ export async function emoteUrnsValidateFn(deployment: DeploymentToValidate): Pro
       const allEmotes = avatar.avatar.emotes ?? []
       for (const { slot, urn } of allEmotes) {
         if (isOldEmote(urn)) continue
-        const parsed = await parseUrn(urn)
+        let parsed
+        try {
+          parsed = await parseUrn(urn)
+        } catch {
+          // treat thrown exceptions the same as unresolvable URNs
+        }
         if (!parsed)
           return validationFailed(
             `Each profile emote pointer should be a urn, for example (urn:decentraland:{protocol}:collections-v2:{contract(0x[a-fA-F0-9]+)}:{name}). Invalid pointer: (${urn})`
@@ -258,7 +268,7 @@ export async function allMandatoryContentFilesArePresentValidateFn(
   async function validateFn(deployment: DeploymentToValidate): Promise<ValidationResponse> {
     const { entity } = deployment
     const errors: string[] = []
-    const fileNames = entity.content.map((a) => a.file.toLowerCase())
+    const fileNames = (entity.content ?? []).map((a) => a.file.toLowerCase())
     if (!fileNames.includes('body.png')) {
       errors.push(`Profile entity is missing file 'body.png'`)
     }
@@ -281,8 +291,9 @@ export async function entityShouldNotHaveContentFilesValidateFn(
   async function validateFn(deployment: DeploymentToValidate): Promise<ValidationResponse> {
     const { entity } = deployment
     const errors: string[] = []
-    if (entity.content.length > 0) {
-      errors.push(`Entity has content files when it should not: ${entity.content.map((a) => a.file).join(', ')}`)
+    const contentFiles = entity.content ?? []
+    if (contentFiles.length > 0) {
+      errors.push(`Entity has content files when it should not: ${contentFiles.map((a) => a.file).join(', ')}`)
     }
     if (deployment.files.size > 1) {
       errors.push(`Entity has uploaded files when it should not: ${Array.from(deployment.files.keys()).join(', ')}`)

--- a/src/validations/profile.ts
+++ b/src/validations/profile.ts
@@ -1,6 +1,6 @@
 import { Avatar, EntityType, Profile } from '@dcl/schemas'
-import { parseUrn } from '@dcl/urn-resolver'
 import sharp from 'sharp'
+import { safeParseUrn } from '../utils'
 import {
   ContentValidatorComponents,
   DeploymentToValidate,
@@ -75,12 +75,7 @@ export async function wearableUrnsValidateFn(deployment: DeploymentToValidate): 
       for (const pointer of avatar.avatar.wearables) {
         if (isOldEmote(pointer)) continue
 
-        let parsed
-        try {
-          parsed = await parseUrn(pointer)
-        } catch {
-          // treat thrown exceptions the same as unresolvable URNs
-        }
+        const parsed = await safeParseUrn(pointer)
         if (!parsed) {
           return validationFailed(
             `Each profile wearable pointer should be a urn, for example (urn:decentraland:{protocol}:collections-v2:{contract(0x[a-fA-F0-9]+)}:{name}). Invalid pointer: (${pointer})`
@@ -107,12 +102,7 @@ export async function emoteUrnsValidateFn(deployment: DeploymentToValidate): Pro
       const allEmotes = avatar.avatar.emotes ?? []
       for (const { slot, urn } of allEmotes) {
         if (isOldEmote(urn)) continue
-        let parsed
-        try {
-          parsed = await parseUrn(urn)
-        } catch {
-          // treat thrown exceptions the same as unresolvable URNs
-        }
+        const parsed = await safeParseUrn(urn)
         if (!parsed)
           return validationFailed(
             `Each profile emote pointer should be a urn, for example (urn:decentraland:{protocol}:collections-v2:{contract(0x[a-fA-F0-9]+)}:{name}). Invalid pointer: (${urn})`

--- a/src/validations/scene.ts
+++ b/src/validations/scene.ts
@@ -26,9 +26,11 @@ export const noWorldsConfigurationValidateFn = validateAfterADR173(async functio
 export const embeddedThumbnail = validateAfterADR236(async function validateFn(
   deployment: DeploymentToValidate
 ): Promise<ValidationResponse> {
-  const sceneThumbnail = deployment.entity.metadata?.display.navmapThumbnail
+  const sceneThumbnail = deployment.entity.metadata?.display?.navmapThumbnail
   if (sceneThumbnail) {
-    const isFilePresent = deployment.entity.content.some((content: ContentMapping) => content.file === sceneThumbnail)
+    const isFilePresent = (deployment.entity.content ?? []).some(
+      (content: ContentMapping) => content.file === sceneThumbnail
+    )
     if (!isFilePresent) {
       return validationFailed(`Scene thumbnail '${sceneThumbnail}' must be a file included in the deployment.`)
     }

--- a/src/validations/timestamps.ts
+++ b/src/validations/timestamps.ts
@@ -1,50 +1,56 @@
+function parseTimestamp(envVar: string | undefined, defaultValue: number): number {
+  if (!envVar) return defaultValue
+  const parsed = parseInt(envVar)
+  return isNaN(parsed) ? defaultValue : parsed
+}
+
 /**
  * 1652191200000 = 2022-05-10T14:00:00Z
  * @public
  */
-export const ADR_45_TIMESTAMP = process.env.ADR_45_TIMESTAMP ? parseInt(process.env.ADR_45_TIMESTAMP) : 1652191200000
+export const ADR_45_TIMESTAMP = parseTimestamp(process.env.ADR_45_TIMESTAMP, 1652191200000)
 
 /**
  * 1658275200000 = 2022-07-20T00:00:00Z
  * @public
  */
-export const ADR_75_TIMESTAMP = process.env.ADR_75_TIMESTAMP ? parseInt(process.env.ADR_75_TIMESTAMP) : 1658275200000
+export const ADR_75_TIMESTAMP = parseTimestamp(process.env.ADR_75_TIMESTAMP, 1658275200000)
 
 /**
- * 1669852800000 = 2022-09-12T13:00:00Z
+ * 1662987600000 = 2022-09-12T13:00:00Z
  * @public
  */
-export const ADR_74_TIMESTAMP = process.env.ADR_74_TIMESTAMP ? parseInt(process.env.ADR_74_TIMESTAMP) : 1662987600000
+export const ADR_74_TIMESTAMP = parseTimestamp(process.env.ADR_74_TIMESTAMP, 1662987600000)
 
 /**
  * 1674576000000 = 2023-01-24T15:00:00Z
  * @public
  */
-export const ADR_158_TIMESTAMP = process.env.ADR_158_TIMESTAMP ? parseInt(process.env.ADR_158_TIMESTAMP) : 1674576000000
+export const ADR_158_TIMESTAMP = parseTimestamp(process.env.ADR_158_TIMESTAMP, 1674576000000)
 
 /**
  * 1673967600000 = 2023-01-17T15:00:00Z
  * @public
  */
-export const ADR_173_TIMESTAMP = process.env.ADR_173_TIMESTAMP ? parseInt(process.env.ADR_173_TIMESTAMP) : 1673967600000
+export const ADR_173_TIMESTAMP = parseTimestamp(process.env.ADR_173_TIMESTAMP, 1673967600000)
 
 /**
  * 1686571200000 = 2023-06-12T12:00:00Z
  * @public
  */
-export const ADR_232_TIMESTAMP = process.env.ADR_232_TIMESTAMP ? parseInt(process.env.ADR_232_TIMESTAMP) : 1686571200000
+export const ADR_232_TIMESTAMP = parseTimestamp(process.env.ADR_232_TIMESTAMP, 1686571200000)
 
 /**
  * 1684497600000 = 2023-05-19T12:00:00Z
  * @public
  */
-export const ADR_236_TIMESTAMP = process.env.ADR_236_TIMESTAMP ? parseInt(process.env.ADR_236_TIMESTAMP) : 1684497600000
+export const ADR_236_TIMESTAMP = parseTimestamp(process.env.ADR_236_TIMESTAMP, 1684497600000)
 
 /**
  * 1710428400000 = 2024-03-14T15:00:00Z
  * @public
  */
-export const ADR_244_TIMESTAMP = process.env.ADR_244_TIMESTAMP ? parseInt(process.env.ADR_244_TIMESTAMP) : 1710428400000
+export const ADR_244_TIMESTAMP = parseTimestamp(process.env.ADR_244_TIMESTAMP, 1710428400000)
 
 const THREE_MONTHS_IN_MS = 3 * 30 * 24 * 60 * 60 * 1000
 
@@ -52,13 +58,12 @@ const THREE_MONTHS_IN_MS = 3 * 30 * 24 * 60 * 60 * 1000
  * 1762743600000 = 2025-11-10T00:00:00Z
  * @public
  */
-export const ADR_290_OPTIONAL_TIMESTAMP = process.env.ADR_290_TIMESTAMP
-  ? parseInt(process.env.ADR_290_TIMESTAMP)
-  : 1762743600000
+export const ADR_290_OPTIONAL_TIMESTAMP = parseTimestamp(process.env.ADR_290_TIMESTAMP, 1762743600000)
 
-export const ADR_290_REJECTED_TIMESTAMP = process.env.ADR_290_REJECTED_TIMESTAMP
-  ? parseInt(process.env.ADR_290_REJECTED_TIMESTAMP)
-  : ADR_290_OPTIONAL_TIMESTAMP + THREE_MONTHS_IN_MS
+export const ADR_290_REJECTED_TIMESTAMP = parseTimestamp(
+  process.env.ADR_290_REJECTED_TIMESTAMP,
+  ADR_290_OPTIONAL_TIMESTAMP + THREE_MONTHS_IN_MS
+)
 
 /**
  * DCL Launch Day

--- a/test/unit/on-chain-access-checker/scenes.spec.ts
+++ b/test/unit/on-chain-access-checker/scenes.spec.ts
@@ -33,6 +33,22 @@ describe('Access: scenes', () => {
     expect(response.ok).toBeFalsy()
   })
 
+  it('When pointers contain non-numeric coordinates, then validation fails with a clear message', async () => {
+    const pointers = ['abc,def']
+    const deployment = buildSceneDeployment(pointers)
+    const externalCalls = buildExternalCalls({
+      isAddressOwnedByDecentraland: () => false,
+      ownerAddress: () => '0xAddress'
+    })
+
+    const validateFn = createSceneValidateFn(buildOnChainAccessCheckerComponents({ externalCalls }))
+    const response = await validateFn(deployment)
+    expect(response.ok).toBeFalsy()
+    expect(response.errors).toContain(
+      'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
+    )
+  })
+
   it('When non-urns are used as pointers, then validation fails', async () => {
     const pointers = ['invalid-pointer']
     const deployment = buildSceneDeployment(pointers)

--- a/test/unit/on-chain-access-checker/scenes.spec.ts
+++ b/test/unit/on-chain-access-checker/scenes.spec.ts
@@ -33,20 +33,25 @@ describe('Access: scenes', () => {
     expect(response.ok).toBeFalsy()
   })
 
-  it('When pointers contain non-numeric coordinates, then validation fails with a clear message', async () => {
-    const pointers = ['abc,def']
-    const deployment = buildSceneDeployment(pointers)
-    const externalCalls = buildExternalCalls({
-      isAddressOwnedByDecentraland: () => false,
-      ownerAddress: () => '0xAddress'
+  describe('and pointers contain non-numeric coordinates', () => {
+    let response: Awaited<ReturnType<ReturnType<typeof createSceneValidateFn>>>
+
+    beforeEach(async () => {
+      const deployment = buildSceneDeployment(['abc,def'])
+      const externalCalls = buildExternalCalls({
+        isAddressOwnedByDecentraland: () => false,
+        ownerAddress: () => '0xAddress'
+      })
+      const validateFn = createSceneValidateFn(buildOnChainAccessCheckerComponents({ externalCalls }))
+      response = await validateFn(deployment)
     })
 
-    const validateFn = createSceneValidateFn(buildOnChainAccessCheckerComponents({ externalCalls }))
-    const response = await validateFn(deployment)
-    expect(response.ok).toBeFalsy()
-    expect(response.errors).toContain(
-      'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
-    )
+    it('should fail with an invalid pointer error', () => {
+      expect(response.ok).toBeFalsy()
+      expect(response.errors).toContain(
+        'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
+      )
+    })
   })
 
   it('When non-urns are used as pointers, then validation fails', async () => {

--- a/test/unit/subgraph-access-checker/scenes.spec.ts
+++ b/test/unit/subgraph-access-checker/scenes.spec.ts
@@ -41,24 +41,25 @@ describe('Access: scenes', () => {
     expect(response.ok).toBeFalsy()
   })
 
-  it('When pointers contain non-numeric coordinates, then validation fails with a clear message', async () => {
-    // Arrange
-    const pointers = ['abc,def']
-    const deployment = buildSceneDeployment(pointers)
-    const externalCalls = buildExternalCalls({
-      isAddressOwnedByDecentraland: () => false,
-      ownerAddress: () => '0xAddress'
+  describe('and pointers contain non-numeric coordinates', () => {
+    let response: Awaited<ReturnType<ReturnType<typeof createSceneValidateFn>>>
+
+    beforeEach(async () => {
+      const deployment = buildSceneDeployment(['abc,def'])
+      const externalCalls = buildExternalCalls({
+        isAddressOwnedByDecentraland: () => false,
+        ownerAddress: () => '0xAddress'
+      })
+      const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
+      response = await validateFn(deployment)
     })
 
-    // Act
-    const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
-    const response = await validateFn(deployment)
-
-    // Assert
-    expect(response.ok).toBeFalsy()
-    expect(response.errors).toContain(
-      'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
-    )
+    it('should fail with an invalid pointer error', () => {
+      expect(response.ok).toBeFalsy()
+      expect(response.errors).toContain(
+        'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
+      )
+    })
   })
 
   it('When non-urns are used as pointers, then validation fails', async () => {

--- a/test/unit/subgraph-access-checker/scenes.spec.ts
+++ b/test/unit/subgraph-access-checker/scenes.spec.ts
@@ -41,6 +41,26 @@ describe('Access: scenes', () => {
     expect(response.ok).toBeFalsy()
   })
 
+  it('When pointers contain non-numeric coordinates, then validation fails with a clear message', async () => {
+    // Arrange
+    const pointers = ['abc,def']
+    const deployment = buildSceneDeployment(pointers)
+    const externalCalls = buildExternalCalls({
+      isAddressOwnedByDecentraland: () => false,
+      ownerAddress: () => '0xAddress'
+    })
+
+    // Act
+    const validateFn = createSceneValidateFn(buildSubgraphAccessCheckerComponents({ externalCalls }))
+    const response = await validateFn(deployment)
+
+    // Assert
+    expect(response.ok).toBeFalsy()
+    expect(response.errors).toContain(
+      'Scene pointers should only contain two integers separated by a comma, for example (10,10) or (120,-45). Invalid pointer: abc,def'
+    )
+  })
+
   it('When non-urns are used as pointers, then validation fails', async () => {
     // Arrange
     const pointers = ['invalid-pointer']

--- a/test/unit/validations/entity-structure.spec.ts
+++ b/test/unit/validations/entity-structure.spec.ts
@@ -1,39 +1,72 @@
+import { DeploymentToValidate, ValidationResponse } from '../../../src/types'
 import { entityStructureValidationFn } from '../../../src/validations/entity-structure'
 import { buildDeployment } from '../../setup/deployments'
 import { buildEntity } from '../../setup/entity'
 
-describe('entityStructureValidationFn', () => {
-  it('when entity has valid pointers, validation passes', async () => {
-    const deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P2'] }) })
-    const result = await entityStructureValidationFn(deployment)
-    expect(result.ok).toBe(true)
+describe('when validating entity structure', () => {
+  let deployment: DeploymentToValidate
+  let result: ValidationResponse
+
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
-  it('when entity has repeated pointers, validation fails', async () => {
-    const deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P1'] }) })
-    const result = await entityStructureValidationFn(deployment)
-    expect(result.ok).toBe(false)
-    expect(result.errors).toContain('There are repeated pointers in your request.')
+  describe('and the entity has valid pointers', () => {
+    beforeEach(async () => {
+      deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P2'] }) })
+      result = await entityStructureValidationFn(deployment)
+    })
+
+    it('should return ok', () => {
+      expect(result.ok).toBe(true)
+    })
   })
 
-  it('when entity has empty pointers array, validation fails', async () => {
-    const deployment = buildDeployment({ entity: buildEntity({ pointers: [] }) })
-    const result = await entityStructureValidationFn(deployment)
-    expect(result.ok).toBe(false)
-    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  describe('and the entity has repeated pointers', () => {
+    beforeEach(async () => {
+      deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P1'] }) })
+      result = await entityStructureValidationFn(deployment)
+    })
+
+    it('should return an error about repeated pointers', () => {
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('There are repeated pointers in your request.')
+    })
   })
 
-  it('when entity pointers is undefined, validation fails instead of throwing', async () => {
-    const deployment = buildDeployment({ entity: buildEntity({ pointers: undefined as any }) })
-    const result = await entityStructureValidationFn(deployment)
-    expect(result.ok).toBe(false)
-    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  describe('and the entity has an empty pointers array', () => {
+    beforeEach(async () => {
+      deployment = buildDeployment({ entity: buildEntity({ pointers: [] }) })
+      result = await entityStructureValidationFn(deployment)
+    })
+
+    it('should return an error about missing pointers', () => {
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+    })
   })
 
-  it('when entity pointers is null, validation fails instead of throwing', async () => {
-    const deployment = buildDeployment({ entity: buildEntity({ pointers: null as any }) })
-    const result = await entityStructureValidationFn(deployment)
-    expect(result.ok).toBe(false)
-    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  describe('and the entity pointers is undefined', () => {
+    beforeEach(async () => {
+      deployment = buildDeployment({ entity: buildEntity({ pointers: undefined as any }) })
+      result = await entityStructureValidationFn(deployment)
+    })
+
+    it('should return an error instead of throwing', () => {
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+    })
+  })
+
+  describe('and the entity pointers is null', () => {
+    beforeEach(async () => {
+      deployment = buildDeployment({ entity: buildEntity({ pointers: null as any }) })
+      result = await entityStructureValidationFn(deployment)
+    })
+
+    it('should return an error instead of throwing', () => {
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+    })
   })
 })

--- a/test/unit/validations/entity-structure.spec.ts
+++ b/test/unit/validations/entity-structure.spec.ts
@@ -1,0 +1,39 @@
+import { entityStructureValidationFn } from '../../../src/validations/entity-structure'
+import { buildDeployment } from '../../setup/deployments'
+import { buildEntity } from '../../setup/entity'
+
+describe('entityStructureValidationFn', () => {
+  it('when entity has valid pointers, validation passes', async () => {
+    const deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P2'] }) })
+    const result = await entityStructureValidationFn(deployment)
+    expect(result.ok).toBe(true)
+  })
+
+  it('when entity has repeated pointers, validation fails', async () => {
+    const deployment = buildDeployment({ entity: buildEntity({ pointers: ['P1', 'P1'] }) })
+    const result = await entityStructureValidationFn(deployment)
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('There are repeated pointers in your request.')
+  })
+
+  it('when entity has empty pointers array, validation fails', async () => {
+    const deployment = buildDeployment({ entity: buildEntity({ pointers: [] }) })
+    const result = await entityStructureValidationFn(deployment)
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  })
+
+  it('when entity pointers is undefined, validation fails instead of throwing', async () => {
+    const deployment = buildDeployment({ entity: buildEntity({ pointers: undefined as any }) })
+    const result = await entityStructureValidationFn(deployment)
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  })
+
+  it('when entity pointers is null, validation fails instead of throwing', async () => {
+    const deployment = buildDeployment({ entity: buildEntity({ pointers: null as any }) })
+    const result = await entityStructureValidationFn(deployment)
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('The entity needs to be pointed by one or more pointers.')
+  })
+})

--- a/test/unit/validations/profiles.spec.ts
+++ b/test/unit/validations/profiles.spec.ts
@@ -1041,15 +1041,17 @@ describe('when validating that all mandatory content files are present', () => {
   })
 
   describe('and entity.content is undefined', () => {
-    beforeEach(() => {
+    let result: ValidationResponse
+
+    beforeEach(async () => {
       deployment = buildDeployment({
         entity: buildProfileEntity({ timestamp: ADR_158_TIMESTAMP + 1000, content: undefined as any }),
         files
       })
+      result = await allMandatoryContentFilesArePresentValidateFn(deployment)
     })
 
-    it('should return an error about missing files instead of throwing', async () => {
-      const result: ValidationResponse = await allMandatoryContentFilesArePresentValidateFn(deployment)
+    it('should return an error about missing files instead of throwing', () => {
       expect(result.ok).toBe(false)
       expect(result.errors).toContain(`Profile entity is missing file 'body.png'`)
     })

--- a/test/unit/validations/profiles.spec.ts
+++ b/test/unit/validations/profiles.spec.ts
@@ -1039,6 +1039,21 @@ describe('when validating that all mandatory content files are present', () => {
       expect(result.errors).toContain(`Profile entity is missing file 'face256.png'`)
     })
   })
+
+  describe('and entity.content is undefined', () => {
+    beforeEach(() => {
+      deployment = buildDeployment({
+        entity: buildProfileEntity({ timestamp: ADR_158_TIMESTAMP + 1000, content: undefined as any }),
+        files
+      })
+    })
+
+    it('should return an error about missing files instead of throwing', async () => {
+      const result: ValidationResponse = await allMandatoryContentFilesArePresentValidateFn(deployment)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain(`Profile entity is missing file 'body.png'`)
+    })
+  })
 })
 
 describe('when validating that the entity should not have content files', () => {

--- a/test/unit/validations/scenes.spec.ts
+++ b/test/unit/validations/scenes.spec.ts
@@ -79,6 +79,43 @@ describe('Scenes', () => {
       expect(result.ok).toBeTruthy()
     })
 
+    it('When entity content is undefined, validation passes without throwing', async () => {
+      const entity = buildEntity({
+        type: EntityType.SCENE,
+        metadata: {
+          ...VALID_SCENE_METADATA,
+          display: {
+            ...VALID_SCENE_METADATA.display,
+            navmapThumbnail: 'thumbnail.png'
+          }
+        },
+        content: undefined as any,
+        timestamp
+      })
+      const deployment = buildDeployment({ entity, files })
+
+      const result: ValidationResponse = await embeddedThumbnail(deployment)
+
+      expect(result.ok).toBeFalsy()
+    })
+
+    it('When metadata display is undefined, validation passes without throwing', async () => {
+      const entity = buildEntity({
+        type: EntityType.SCENE,
+        metadata: {
+          ...VALID_SCENE_METADATA,
+          display: undefined
+        },
+        content,
+        timestamp
+      })
+      const deployment = buildDeployment({ entity, files })
+
+      const result: ValidationResponse = await embeddedThumbnail(deployment)
+
+      expect(result.ok).toBeTruthy()
+    })
+
     it('When there is a thumbnail that does not reference an embedded file, validation fails with error', async () => {
       const entity = buildEntity({
         type: EntityType.SCENE,

--- a/test/unit/validations/scenes.spec.ts
+++ b/test/unit/validations/scenes.spec.ts
@@ -79,41 +79,45 @@ describe('Scenes', () => {
       expect(result.ok).toBeTruthy()
     })
 
-    it('When entity content is undefined, validation passes without throwing', async () => {
-      const entity = buildEntity({
-        type: EntityType.SCENE,
-        metadata: {
-          ...VALID_SCENE_METADATA,
-          display: {
-            ...VALID_SCENE_METADATA.display,
-            navmapThumbnail: 'thumbnail.png'
-          }
-        },
-        content: undefined as any,
-        timestamp
+    describe('and entity content is undefined', () => {
+      let result: ValidationResponse
+
+      beforeEach(async () => {
+        const entity = buildEntity({
+          type: EntityType.SCENE,
+          metadata: {
+            ...VALID_SCENE_METADATA,
+            display: { ...VALID_SCENE_METADATA.display, navmapThumbnail: 'thumbnail.png' }
+          },
+          content: undefined as any,
+          timestamp
+        })
+        const deployment = buildDeployment({ entity, files })
+        result = await embeddedThumbnail(deployment)
       })
-      const deployment = buildDeployment({ entity, files })
 
-      const result: ValidationResponse = await embeddedThumbnail(deployment)
-
-      expect(result.ok).toBeFalsy()
+      it('should fail validation instead of throwing', async () => {
+        expect(result.ok).toBeFalsy()
+      })
     })
 
-    it('When metadata display is undefined, validation passes without throwing', async () => {
-      const entity = buildEntity({
-        type: EntityType.SCENE,
-        metadata: {
-          ...VALID_SCENE_METADATA,
-          display: undefined
-        },
-        content,
-        timestamp
+    describe('and metadata display is undefined', () => {
+      let result: ValidationResponse
+
+      beforeEach(async () => {
+        const entity = buildEntity({
+          type: EntityType.SCENE,
+          metadata: { ...VALID_SCENE_METADATA, display: undefined },
+          content,
+          timestamp
+        })
+        const deployment = buildDeployment({ entity, files })
+        result = await embeddedThumbnail(deployment)
       })
-      const deployment = buildDeployment({ entity, files })
 
-      const result: ValidationResponse = await embeddedThumbnail(deployment)
-
-      expect(result.ok).toBeTruthy()
+      it('should pass validation without throwing', async () => {
+        expect(result.ok).toBeTruthy()
+      })
     })
 
     it('When there is a thumbnail that does not reference an embedded file, validation fails with error', async () => {

--- a/test/unit/validations/timestamps.spec.ts
+++ b/test/unit/validations/timestamps.spec.ts
@@ -1,0 +1,36 @@
+describe('parseTimestamp', () => {
+  const ORIGINAL_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('should use the default value when env var is not set', async () => {
+    delete process.env.ADR_45_TIMESTAMP
+    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  })
+
+  it('should use the env var value when it is a valid number', async () => {
+    process.env.ADR_45_TIMESTAMP = '9999999999999'
+    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+    expect(ADR_45_TIMESTAMP).toBe(9999999999999)
+  })
+
+  it('should fall back to default when env var is not a valid number', async () => {
+    process.env.ADR_45_TIMESTAMP = 'invalid'
+    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  })
+
+  it('should fall back to default when env var is an empty string', async () => {
+    process.env.ADR_45_TIMESTAMP = ''
+    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  })
+})

--- a/test/unit/validations/timestamps.spec.ts
+++ b/test/unit/validations/timestamps.spec.ts
@@ -1,4 +1,4 @@
-describe('parseTimestamp', () => {
+describe('when parsing timestamp environment variables', () => {
   const ORIGINAL_ENV = process.env
 
   beforeEach(() => {
@@ -6,31 +6,51 @@ describe('parseTimestamp', () => {
     process.env = { ...ORIGINAL_ENV }
   })
 
-  afterAll(() => {
+  afterEach(() => {
     process.env = ORIGINAL_ENV
   })
 
-  it('should use the default value when env var is not set', async () => {
-    delete process.env.ADR_45_TIMESTAMP
-    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
-    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  describe('and the env var is not set', () => {
+    beforeEach(() => {
+      delete process.env.ADR_45_TIMESTAMP
+    })
+
+    it('should use the default value', async () => {
+      const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+      expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+    })
   })
 
-  it('should use the env var value when it is a valid number', async () => {
-    process.env.ADR_45_TIMESTAMP = '9999999999999'
-    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
-    expect(ADR_45_TIMESTAMP).toBe(9999999999999)
+  describe('and the env var is a valid number', () => {
+    beforeEach(() => {
+      process.env.ADR_45_TIMESTAMP = '9999999999999'
+    })
+
+    it('should use the parsed value', async () => {
+      const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+      expect(ADR_45_TIMESTAMP).toBe(9999999999999)
+    })
   })
 
-  it('should fall back to default when env var is not a valid number', async () => {
-    process.env.ADR_45_TIMESTAMP = 'invalid'
-    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
-    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  describe('and the env var is not a valid number', () => {
+    beforeEach(() => {
+      process.env.ADR_45_TIMESTAMP = 'invalid'
+    })
+
+    it('should fall back to the default value', async () => {
+      const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+      expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+    })
   })
 
-  it('should fall back to default when env var is an empty string', async () => {
-    process.env.ADR_45_TIMESTAMP = ''
-    const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
-    expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+  describe('and the env var is an empty string', () => {
+    beforeEach(() => {
+      process.env.ADR_45_TIMESTAMP = ''
+    })
+
+    it('should fall back to the default value', async () => {
+      const { ADR_45_TIMESTAMP } = await import('../../../src/validations/timestamps')
+      expect(ADR_45_TIMESTAMP).toBe(1652191200000)
+    })
   })
 })

--- a/test/unit/validations/utils.spec.ts
+++ b/test/unit/validations/utils.spec.ts
@@ -1,20 +1,44 @@
 import { safeParseUrn } from '../../../src/utils'
 
-describe('safeParseUrn', () => {
-  it('should return the parsed result for a valid URN', async () => {
-    const urn = 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0'
-    const result = await safeParseUrn(urn)
-    expect(result).toBeDefined()
-    expect(result?.type).toBe('blockchain-collection-v2-asset')
+describe('when parsing a URN with safeParseUrn', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
-  it('should return null for an unresolvable URN', async () => {
-    const result = await safeParseUrn('urn:decentraland:invalid')
-    expect(result).toBeNull()
+  describe('and the URN is valid', () => {
+    let result: Awaited<ReturnType<typeof safeParseUrn>>
+
+    beforeEach(async () => {
+      result = await safeParseUrn('urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0')
+    })
+
+    it('should return the parsed result', () => {
+      expect(result).toBeDefined()
+      expect(result?.type).toBe('blockchain-collection-v2-asset')
+    })
   })
 
-  it('should return null instead of throwing for a malformed input', async () => {
-    const result = await safeParseUrn('')
-    expect(result).toBeNull()
+  describe('and the URN is unresolvable', () => {
+    let result: Awaited<ReturnType<typeof safeParseUrn>>
+
+    beforeEach(async () => {
+      result = await safeParseUrn('urn:decentraland:invalid')
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('and the input is malformed', () => {
+    let result: Awaited<ReturnType<typeof safeParseUrn>>
+
+    beforeEach(async () => {
+      result = await safeParseUrn('')
+    })
+
+    it('should return null instead of throwing', () => {
+      expect(result).toBeNull()
+    })
   })
 })

--- a/test/unit/validations/utils.spec.ts
+++ b/test/unit/validations/utils.spec.ts
@@ -1,0 +1,20 @@
+import { safeParseUrn } from '../../../src/utils'
+
+describe('safeParseUrn', () => {
+  it('should return the parsed result for a valid URN', async () => {
+    const urn = 'urn:decentraland:matic:collections-v2:0xf6f601efee04e74cecac02c8c5bdc8cc0fc1c721:0'
+    const result = await safeParseUrn(urn)
+    expect(result).toBeDefined()
+    expect(result?.type).toBe('blockchain-collection-v2-asset')
+  })
+
+  it('should return null for an unresolvable URN', async () => {
+    const result = await safeParseUrn('urn:decentraland:invalid')
+    expect(result).toBeNull()
+  })
+
+  it('should return null instead of throwing for a malformed input', async () => {
+    const result = await safeParseUrn('')
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Several code paths in the validator can crash with unhandled exceptions instead of returning proper validation errors. This PR adds defensive guards so the validator fails gracefully with clear error messages rather than throwing.

### Why these changes are needed

- **`entity-structure.ts`**: The null/empty check on `entity.pointers` runs *after* `new Set(entity.pointers)`, which throws a `TypeError` if `pointers` is `null`. The null check is unreachable in the crash case. Reordering puts the null check first so it catches the problem before the `Set` constructor runs.

- **`timestamps.ts`**: All 10 ADR timestamp constants are overridable via environment variables using `parseInt()`, but none validate the result. If an env var is set to a non-numeric value (e.g. `"invalid"`), `parseInt` returns `NaN`, and since `NaN >= anyNumber` is always `false`, the corresponding `validateAfterADRxx` gate silently disables the wrapped validator. A single misconfigured env var like `ADR_45_TIMESTAMP=invalid` would disable IPFS hashing, metadata schema, thumbnail, and content validation — with no log message. A shared `parseTimestamp` helper now falls back to the default when the parsed value is `NaN`. The incorrect timestamp number in the ADR-74 comment is also fixed.

- **`scene.ts`**: `metadata?.display.navmapThumbnail` uses optional chaining on `metadata` but not on `display`. If `metadata` exists but `display` is `undefined`, this throws. Similarly, `entity.content.some(...)` throws if `content` is `undefined`. Added optional chaining on both.

- **`profile.ts`**: `entity.content.map(...)` at two call sites throws if `content` is `undefined`. Other locations in the same file already guard with `entity.content ?? []`; these two were missed. Also, `parseUrn()` from `@dcl/urn-resolver` is async and can throw on malformed input, but the wearable and emote URN validators call it without try-catch. If it throws instead of returning `null`, the entire validator crashes. Added try-catch that treats thrown exceptions the same as unresolvable URNs.

- **`outfits.ts`** and **`utils.ts`**: Same `parseUrn` throw risk — wrapped in try-catch.

- **`subgraph/scenes.ts`**: The scene access validator accesses `estate.owners[0].address` and `parcel.owners[0].address` without checking if the `owners` array has elements. The subgraph queries filter by `createdAt_lte: $timestamp` with `first: 1`, so if no ownership record exists at the queried timestamp, the array is empty and `[0].address` throws a `TypeError`. This crashes into the `retry()` loop (5 retries, 100ms each), then propagates as an internal error. The fix checks `owners.length` first and returns `false` (no access) when empty. Also adds `isNaN` validation after `parseInt` on pointer coordinates so `"abc,def"` produces a clear "invalid pointer" error instead of passing `NaN` to GraphQL queries. The typo "state" in an error message is corrected to "estate".

- **`on-chain/scenes.ts`**: Same `isNaN` guard added for pointer coordinate parsing.

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] `npm test` — all 325 existing tests pass
- [ ] `npm run lint:check` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)